### PR TITLE
Workaround mask-image CSS property to prevent crash in Edge

### DIFF
--- a/mixins/menu-overlay.html
+++ b/mixins/menu-overlay.html
@@ -53,6 +53,15 @@
           background-image: inherit;
           --_lumo-menu-overlay-mask-image: linear-gradient(#000, transparent 40px, transparent calc(100% - 40px), #000);
           -webkit-mask-image: var(--_lumo-menu-overlay-mask-image);
+        }
+      }
+
+      /*
+        TODO: CSS custom property in `mask-image` causes crash in Edge
+        see https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/15415089/
+      */
+      @-moz-document url-prefix() {
+        :host([phone]) [part="overlay"]::after {
           mask-image: var(--_lumo-menu-overlay-mask-image);
         }
       }


### PR DESCRIPTION
Connected to vaadin/vaadin-valo-styles#45

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-lumo-styles/1)
<!-- Reviewable:end -->
