### PR TITLE
Use html-tag in P3 converted style modules

### DIFF
--- a/magi-p3-post.js
+++ b/magi-p3-post.js
@@ -1,11 +1,21 @@
+const fixme = `
+/*
+  FIXME(polymer-modulizer): the above comments were extracted
+  from HTML and may be out of place here. Review them and
+  then delete this comment!
+*/
+;`
+
 module.exports = {
   files: require('./package.json').files,
   from: [
     "const $_documentContainer = document.createElement('template');",
-    "$_documentContainer.innerHTML = `"
+    "$_documentContainer.innerHTML = `",
+    fixme
   ],
   to: [
     "import { html } from '@polymer/polymer/lib/utils/html-tag.js';",
-    "const $_documentContainer = html`"
+    "const $_documentContainer = html`",
+    ""
   ]
 }

--- a/magi-p3-post.js
+++ b/magi-p3-post.js
@@ -1,0 +1,11 @@
+module.exports = {
+  files: require('./package.json').files,
+  from: [
+    "const $_documentContainer = document.createElement('template');",
+    "$_documentContainer.innerHTML = `"
+  ],
+  to: [
+    "import { html } from '@polymer/polymer/lib/utils/html-tag.js';",
+    "const $_documentContainer = html`"
+  ]
+}


### PR DESCRIPTION
## Description

As a developer, I want to use the tagged template literals (instead of usual template literals) when converting to Polymer 3, in order to get the proper support for modern tools and plugins.

### Current

```js
const $_documentContainer = document.createElement('template');

$_documentContainer.innerHTML = `<custom-style>
  <style>
    html {
      --lumo-size-xs: 1.625rem;
      --lumo-size-s: 1.875rem;
      --lumo-size-m: 2.25rem;
      --lumo-size-l: 2.75rem;
      --lumo-size-xl: 3.5rem;

      /* Icons */
      --lumo-icon-size-s: 1.25em;
      --lumo-icon-size-m: 1.5em;
      --lumo-icon-size-l: 2.25em;
      /* For backwards compatibility */
      --lumo-icon-size: var(--lumo-icon-size-m);
    }
  </style>
</custom-style>`;

document.head.appendChild($_documentContainer.content);
```

### Expected

```js
import { html } from '@polymer/polymer/lib/utils/html-tag.js';

const $_documentContainer = html`<custom-style>
  <style>
    html {
      --lumo-size-xs: 1.625rem;
      --lumo-size-s: 1.875rem;
      --lumo-size-m: 2.25rem;
      --lumo-size-l: 2.75rem;
      --lumo-size-xl: 3.5rem;

      /* Icons */
      --lumo-icon-size-s: 1.25em;
      --lumo-icon-size-m: 1.5em;
      --lumo-icon-size-l: 2.25em;
      /* For backwards compatibility */
      --lumo-icon-size: var(--lumo-icon-size-m);
    }
  </style>
</custom-style>`;

document.head.appendChild($_documentContainer.content);
```

### Possible benefits
- support for [babel-plugin-template-html-minifier](https://github.com/goto-bus-stop/babel-plugin-template-html-minifier): easy to minify CSS, especially remove comments from the above code
- support for [VSCode plugin](https://github.com/mjbvz/vscode-lit-html) syntax highlighting

### Possible negative effects
- code transpiled by Babel will get larger because of how it transpiles tagged template literals, but the outcome does not seem noticeable, especially when compared with benefit of CSS minifying

Note: requested in Polymer/polymer-modulizer#449 but I was unable to quickly implement it there.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-lumo-styles/29)
<!-- Reviewable:end -->
