### PR TITLE
fix(edge): transparent outline: 1px -> 0px

### DIFF
--- a/mixins/overlay.html
+++ b/mixins/overlay.html
@@ -13,6 +13,8 @@
         left: var(--lumo-space-m);
         /* Workaround for Edge issue (only on Surface), where an overflowing vaadin-list-box inside vaadin-dropdown-menu-overlay makes the overlay transparent */
         outline: 0px solid transparent;
+        /* Workaround for Chrome on macOS, prevent jumpiness when scrolling */
+        will-change: transform;
       }
 
       [part="overlay"] {

--- a/mixins/overlay.html
+++ b/mixins/overlay.html
@@ -12,7 +12,7 @@
         bottom: var(--lumo-space-m);
         left: var(--lumo-space-m);
         /* Workaround for Edge issue (only on Surface), where an overflowing vaadin-list-box inside vaadin-dropdown-menu-overlay makes the overlay transparent */
-        outline: 1px solid transparent;
+        outline: 0px solid transparent;
       }
 
       [part="overlay"] {


### PR DESCRIPTION
Fixes https://github.com/vaadin/vaadin-overlay/issues/128 

Please don't ask me why a fixed positioned block is jumpy with 1px transparent outline and not jumpy with 0px transparent outline. It's the secret knowledge of MS devs :)

Manually tested on both desktop and Surface.

---

The jumpiness issue isn't happening for Material theme, so I'm not sure if `outline: 0px solid transparent` should be moved to `vaadin-overlay`'s styles. @jouni wdyt?


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-lumo-styles/46)
<!-- Reviewable:end -->
