### PR TITLE
Add more border radius and box shadow variants

### DIFF
--- a/badge.html
+++ b/badge.html
@@ -10,10 +10,10 @@
         align-items: center;
         justify-content: center;
         box-sizing: border-box;
-        padding: 0.4em calc(0.5em + var(--lumo-border-radius) / 4);
+        padding: 0.4em calc(0.5em + var(--lumo-border-radius-s) / 4);
         color: var(--lumo-primary-text-color);
         background-color: var(--lumo-primary-color-10pct);
-        border-radius: var(--lumo-border-radius);
+        border-radius: var(--lumo-border-radius-s);
         font-family: var(--lumo-font-family);
         font-size: var(--lumo-font-size-s);
         line-height: 1;

--- a/color.html
+++ b/color.html
@@ -181,7 +181,7 @@
       code,
       pre {
         background-color: var(--lumo-contrast-10pct);
-        border-radius: var(--lumo-border-radius);
+        border-radius: var(--lumo-border-radius-m);
       }
     </style>
   </template>

--- a/demo/colors.html
+++ b/demo/colors.html
@@ -21,7 +21,7 @@
       nice-demo-snippet > div,
       nice-demo-snippet > .demo > div {
         display: flex;
-        border-radius: var(--lumo-border-radius);
+        border-radius: var(--lumo-border-radius-m);
         overflow: hidden;
       }
 

--- a/demo/common.html
+++ b/demo/common.html
@@ -91,6 +91,8 @@
 
     dl.custom-properties dd {
       color: var(--lumo-secondary-text-color);
+      margin-bottom: 1em;
+      margin-left: 1.2em;
     }
 
     dl.custom-properties dt code {
@@ -108,7 +110,7 @@
 
     code {
       background-color: var(--lumo-shade-5pct);
-      border-radius: var(--lumo-border-radius);
+      border-radius: var(--lumo-border-radius-m);
       padding: 0 0.2em;
       font-family: "Source Code Pro", "Courier New", Courier, monospace;
       font-size: var(--lumo-font-size-s);
@@ -124,7 +126,7 @@
     }
 
     nice-demo-snippet {
-      border-radius: var(--lumo-border-radius);
+      border-radius: var(--lumo-border-radius-m);
       --nice-demo-snippet-code-font-family: Menlo, Consolas, monospace;
       --nice-demo-snippet-code-background-color: var(--lumo-shade-5pct);
       --nice-demo-snippet-border-color: var(--lumo-contrast-10pct);

--- a/demo/icons.html
+++ b/demo/icons.html
@@ -249,7 +249,7 @@
             align-items: center;
             cursor: pointer;
             position: relative;
-            border-radius: var(--lumo-border-radius);
+            border-radius: var(--lumo-border-radius-m);
           }
 
           :host(:hover:not(:focus)) {
@@ -329,7 +329,7 @@
             background-color: var(--lumo-base-color);
             background-image: linear-gradient(var(--lumo-contrast-5pct), var(--lumo-contrast-5pct));
             pointer-events: none;
-            border-radius: var(--lumo-border-radius);
+            border-radius: var(--lumo-border-radius-m);
             padding: 0.5em 0.75em;
             margin: 0.4em 0;
             min-width: 100%;

--- a/demo/styles.html
+++ b/demo/styles.html
@@ -113,11 +113,11 @@
               border-radius: var(--lumo-border-radius-s);
             }
 
-            .radius.medium {
+            .radius.m {
               border-radius: var(--lumo-border-radius-m);
             }
 
-            .radius.large {
+            .radius.l {
               border-radius: var(--lumo-border-radius-l);
             }
           </style>

--- a/demo/styles.html
+++ b/demo/styles.html
@@ -19,26 +19,55 @@
 
   <custom-style>
     <style>
-      [class^="box"] {
-        display: inline-block;
-        width: var(--lumo-size-xl);
-        height: var(--lumo-size-xl);
-        margin: var(--lumo-space-s);
-        background-color: var(--lumo-contrast-20pct);
-      }
-
-      [class^="shadow"] {
+      .box {
         display: inline-flex;
         align-items: center;
         justify-content: center;
         font-weight: 600;
         color: var(--lumo-secondary-text-color);
-        font-size: var(--lumo-font-size-s);
         width: var(--lumo-size-xl);
         height: var(--lumo-size-xl);
         margin: var(--lumo-space-xl);
-        border-radius: var(--lumo-border-radius);
+        border-radius: var(--lumo-border-radius-m);
         background-color: var(--lumo-tint-5pct);
+      }
+
+      .shadow {
+        background-color: var(--lumo-base-color);
+        background-image: linear-gradient(var(--lumo-tint-5pct), var(--lumo-tint-5pct));
+      }
+
+      .shadows {
+        background-image: linear-gradient(var(--lumo-shade-5pct), var(--lumo-shade-5pct));
+      }
+
+      .radius {
+        background-color: var(--lumo-contrast-20pct);
+      }
+
+      .box::before {
+        content: "";
+        font-size: var(--lumo-font-size-s);
+      }
+
+      .box.xs::before {
+        content: "XS";
+      }
+
+      .box.s::before {
+        content: "S";
+      }
+
+      .box.m::before {
+        content: "M";
+      }
+
+      .box.l::before {
+        content: "L";
+      }
+
+      .box.xl::before {
+        content: "XL";
       }
     </style>
   </custom-style>
@@ -66,30 +95,30 @@
 
     <h2 demo-section>Border radius</h2>
 
-    <p>You can adjust the top level border radius, which affects many element themes directly.</p>
+    <p>The border radius values are defined as <code>em</code> by default, so they scale with the font size.</p>
     <div class="note">
       <h6>Removing border radius</h6>
-      <p>If you want to set the border radius to zero, you need to specify a unit for it as well (i.e. <code>0px</code> or <code>0em</code>), as it can be used in <code>calc</code> functions which will be undefined if <code>--lumo-border-radius</code> is a unitless value.</p>
+      <p>If you want to set a border radius property to zero, you need to specify a unit for it as well (i.e. <code>0px</code> or <code>0em</code>), as it can be used in <code>calc</code> functions which will be undefined if the border radius is a unitless value.</p>
     </div>
 
     <nice-demo-snippet>
       <template slot="source">
-        <div class="box"></div>
-        <div class="box box2"></div>
-        <div class="box box3"></div>
+        <div class="box s radius"></div>
+        <div class="box m radius"></div>
+        <div class="box l radius"></div>
 
         <custom-style>
           <style>
-            .box {
-              border-radius: var(--lumo-border-radius);
+            .radius.s {
+              border-radius: var(--lumo-border-radius-s);
             }
 
-            .box2 {
-              --lumo-border-radius: 0.5em;
+            .radius.medium {
+              border-radius: var(--lumo-border-radius-m);
             }
 
-            .box3 {
-              --lumo-border-radius: 1em;
+            .radius.large {
+              border-radius: var(--lumo-border-radius-l);
             }
           </style>
         </custom-style>
@@ -98,37 +127,40 @@
 
 
 
-    <h2 demo-section>Box Shadow</h2>
+    <h2 demo-section>Shadow</h2>
 
-    <nice-demo-snippet>
+    <p>Shadows are used to indicate elements which are stacked on top of other elements in the UI.</p>
+
+    <nice-demo-snippet class="shadows">
       <template slot="source">
-        <div class="shadow-s">S</div>
-        <div class="shadow-m">M</div>
-        <div class="shadow-l">L</div>
-        <div class="shadow-xl">XL</div>
+        <div class="box xs shadow"></div>
+        <div class="box s shadow"></div>
+        <div class="box m shadow"></div>
+        <div class="box l shadow"></div>
+        <div class="box xl shadow"></div>
 
         <custom-style>
           <style>
-            .shadow-s {
+            .shadow.xs {
+              box-shadow: var(--lumo-box-shadow-xs);
+            }
+
+            .shadow.s {
               box-shadow: var(--lumo-box-shadow-s);
-              width: var(--lumo-size-m);
-              height: var(--lumo-size-m);
             }
 
-            .shadow-m {
+            .shadow.m {
               box-shadow: var(--lumo-box-shadow-m);
-              width: var(--lumo-size-l);
-              height: var(--lumo-size-l);
             }
 
-            .shadow-l {
+            .shadow.l {
               box-shadow: var(--lumo-box-shadow-l);
-              width: var(--lumo-size-xl);
-              height: var(--lumo-size-xl);
             }
 
-            .shadow-xl {
+            .shadow.xl {
               box-shadow: var(--lumo-box-shadow-xl);
+              width: calc(var(--lumo-size-xl) * 1.2);
+              height: calc(var(--lumo-size-xl) * 1.2);
             }
           </style>
         </custom-style>
@@ -168,15 +200,29 @@
 
     <h5>Border radius</h5>
     <dl class="custom-properties">
-      <dt>--lumo-border-radius</dt>
+      <dt>--lumo-border-radius-s</dt>
+        <dd>Use for small elements. To ensure they never turn into full circles, keep this value below <code>0.5em</code>.</dd>
+      <dt>--lumo-border-radius-m</dt>
+        <dd>The most commonly used roundness. It’s recommended to keep the value between <code>0em</code> and <code>calc(var(--lumo-size-m) / 2)</code></dd>
+      <dt>--lumo-border-radius-l</dt>
+        <dd>Use for large containers, such as cards and dialogs. It’s recommended to keep the value between <code>0em</code> and <code>0.5em</code></dd>
+      <dt>--lumo-border-radius: <code>var(--lumo-border-radius-m)</code></dt>
+        <dd>Deprecated. Use <code>--lumo-border-radius-m</code> instead.</dd>
     </dl>
 
     <h5>Shadow</h5>
+    <p theme="font-size-s">The shadows use various <code>--lumo-shade</code> colors. Computed values are shown here instead of the declared values.</p>
     <dl class="custom-properties">
+      <dt>--lumo-box-shadow-xs</dt>
+        <dd>Elements closest to the application background, for example cards.</dd>
       <dt>--lumo-box-shadow-s</dt>
+        <dd>Tooltips, etc.</dd>
       <dt>--lumo-box-shadow-m</dt>
+        <dd>Contextual popups, such as select menus.</dd>
       <dt>--lumo-box-shadow-l</dt>
+        <dd>Elements that rise above above most elements in the UI, for example dialogs.</dd>
       <dt>--lumo-box-shadow-xl</dt>
+        <dd>Elements highest in the stacking order, for example notifications, which should be above all other content.</dd>
     </dl>
 
     <h5>Interaction</h5>

--- a/mixins/overlay.html
+++ b/mixins/overlay.html
@@ -19,7 +19,7 @@
       [part="overlay"] {
         background-color: var(--lumo-base-color);
         background-image: linear-gradient(var(--lumo-tint-5pct), var(--lumo-tint-5pct));
-        border-radius: var(--lumo-border-radius);
+        border-radius: var(--lumo-border-radius-m);
         box-shadow: 0 0 0 1px var(--lumo-shade-5pct), var(--lumo-box-shadow-m);
         color: var(--lumo-body-text-color);
         font-family: var(--lumo-font-family);

--- a/mixins/required-field.html
+++ b/mixins/required-field.html
@@ -11,7 +11,7 @@
         color: var(--lumo-secondary-text-color);
         font-weight: 500;
         font-size: var(--lumo-font-size-s);
-        margin-left: calc(var(--lumo-border-radius) / 4);
+        margin-left: calc(var(--lumo-border-radius-m) / 4);
         transition: color 0.2s;
         line-height: 1;
         padding-bottom: 0.5em;
@@ -55,7 +55,7 @@
       }
 
       [part="error-message"] {
-        margin-left: calc(var(--lumo-border-radius) / 4);
+        margin-left: calc(var(--lumo-border-radius-m) / 4);
         font-size: var(--lumo-font-size-xs);
         line-height: var(--lumo-line-height-xs);
         color: var(--lumo-error-text-color);

--- a/style.html
+++ b/style.html
@@ -4,10 +4,15 @@
 <custom-style>
   <style>
     html {
-      --lumo-border-radius: 0.25em;
+      /* Border radius */
+      --lumo-border-radius-s: 0.25em; /* Checkbox, badge, date-picker year indicator, etc */
+      --lumo-border-radius-m: 0.25em; /* Button, text field, menu overlay, etc */
+      --lumo-border-radius-l: 0.5em; /* Dialog, notification, etc */
+      --lumo-border-radius: var(--lumo-border-radius-m); /* Backwards compatibility */
 
-      /* Shadows */
-      --lumo-box-shadow-s: 0 1px 2px 0 var(--lumo-shade-20pct), 0 2px 8px -2px var(--lumo-shade-40pct);
+      /* Shadow */
+      --lumo-box-shadow-xs: 0 1px 4px -1px var(--lumo-shade-50pct);
+      --lumo-box-shadow-s: 0 2px 4px -1px var(--lumo-shade-20pct), 0 3px 12px -1px var(--lumo-shade-30pct);
       --lumo-box-shadow-m: 0 2px 6px -1px var(--lumo-shade-20pct), 0 8px 24px -4px var(--lumo-shade-40pct);
       --lumo-box-shadow-l: 0 3px 18px -2px var(--lumo-shade-20pct), 0 12px 48px -6px var(--lumo-shade-40pct);
       --lumo-box-shadow-xl: 0 4px 24px -3px var(--lumo-shade-20pct), 0 18px 64px -8px var(--lumo-shade-40pct);

--- a/typography.html
+++ b/typography.html
@@ -123,7 +123,7 @@
         height: 1px;
         border: 0;
         padding: 0;
-        margin: var(--lumo-space-s) calc(var(--lumo-border-radius) / 2);
+        margin: var(--lumo-space-s) calc(var(--lumo-border-radius-m) / 2);
         background-color: var(--lumo-contrast-10pct);
       }
 


### PR DESCRIPTION
Fixes #42 

### Changes: 

- Add 3 degrees for border radius properties
- Deprecate the “global” `--lumo-border-radius` 
  - **Add a mention about the deprecation in the release notes**
- Add a small shadow variant

Shadows before:

![screen shot 2019-01-14 at 16 58 18](https://user-images.githubusercontent.com/66382/51120937-da2d5400-181e-11e9-8c23-edc484871b64.png)


Shadows after:

![screen shot 2019-01-14 at 16 58 25](https://user-images.githubusercontent.com/66382/51120953-df8a9e80-181e-11e9-8dfc-7a519c4d5b57.png)

I adjust the S shadow at the same time, so that the progression from M to XS is more natural.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-lumo-styles/57)
<!-- Reviewable:end -->