### PR TITLE
Revert breaking change to --lumo-border-radius

### DIFF
--- a/demo/styles.html
+++ b/demo/styles.html
@@ -206,7 +206,7 @@
         <dd>The most commonly used roundness. It’s recommended to keep the value between <code>0em</code> and <code>calc(var(--lumo-size-m) / 2)</code></dd>
       <dt>--lumo-border-radius-l</dt>
         <dd>Use for large containers, such as cards and dialogs. It’s recommended to keep the value between <code>0em</code> and <code>0.5em</code></dd>
-      <dt>--lumo-border-radius: <code>var(--lumo-border-radius-m)</code></dt>
+      <dt>--lumo-border-radius</dt>
         <dd>Deprecated. Use <code>--lumo-border-radius-m</code> instead.</dd>
     </dl>
 

--- a/style.html
+++ b/style.html
@@ -6,9 +6,9 @@
     html {
       /* Border radius */
       --lumo-border-radius-s: 0.25em; /* Checkbox, badge, date-picker year indicator, etc */
-      --lumo-border-radius-m: 0.25em; /* Button, text field, menu overlay, etc */
+      --lumo-border-radius-m: var(--lumo-border-radius, 0.25em); /* Button, text field, menu overlay, etc */
       --lumo-border-radius-l: 0.5em; /* Dialog, notification, etc */
-      --lumo-border-radius: var(--lumo-border-radius-m); /* Backwards compatibility */
+      --lumo-border-radius: 0.25em; /* Deprecated */
 
       /* Shadow */
       --lumo-box-shadow-xs: 0 1px 4px -1px var(--lumo-shade-50pct);


### PR DESCRIPTION
The deprecated property still takes precedence.

## Release notes should contain something like this:

Fixed `--lumo-border-radius` deprecation, so that existing theme customizations will still work as expected.

Until all components using Lumo have been updated to use the new roundness properties, you should keep using the deprecated `--lumo-border-radius` property for controlling the medium roundness. Otherwise you might get mixed results, some components being affected and others not.

After you’ve updated your component dependencies to versions that use the new roundness properties, you can switch from `--lumo-border-radius` to `--lumo-border-radius-m` in your theme overrides.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-lumo-styles/61)
<!-- Reviewable:end -->
