### PR TITLE
Add RTL specific styles

### DIFF
--- a/badge.html
+++ b/badge.html
@@ -142,6 +142,18 @@
       [theme~="badge"][theme~="pill"] {
         --lumo-border-radius-s: 1em;
       }
+
+      /* RTL specific styles */
+
+      [dir="rtl"][theme~="badge"] iron-icon:first-child {
+        margin-right: -0.375em;
+        margin-left: 0;
+      }
+
+      [dir="rtl"][theme~="badge"] iron-icon:last-child {
+        margin-left: -0.375em;
+        margin-right: 0;
+      }
     </style>
   </template>
 </dom-module>

--- a/mixins/required-field.html
+++ b/mixins/required-field.html
@@ -76,6 +76,29 @@
         max-height: 0;
         overflow: hidden;
       }
+
+      /* RTL specific styles */
+
+      :host([dir="rtl"]) [part="label"] {
+        margin-left: 0;
+        margin-right: calc(var(--lumo-border-radius-m) / 4);
+      }
+
+      :host([required][dir="rtl"]) [part="label"] {
+        padding-left: 1em;
+        padding-right: 0;
+      }
+
+      :host([dir="rtl"]) [part="label"]::after {
+        right: auto;
+        left: 0;
+      }
+
+      :host([dir="rtl"]) [part="error-message"] {
+        margin-left: 0;
+        margin-right: calc(var(--lumo-border-radius-m) / 4);
+      }
+
     </style>
   </template>
 </dom-module>

--- a/typography.html
+++ b/typography.html
@@ -135,6 +135,14 @@
       strong {
         font-weight: 600;
       }
+
+      /* RTL specific styles */
+
+      blockquote[dir="rtl"] {
+        border-left: none;
+        border-right: 2px solid var(--lumo-contrast-30pct);
+      }
+
     </style>
   </template>
 </dom-module>


### PR DESCRIPTION
Connected to https://github.com/vaadin/vaadin-lumo-styles/issues/77
Connected to https://github.com/vaadin/components-team-tasks/issues/503

**Important**
For `badge` and `blockquote` I am adding styles with `dir` attribute selector. 
There is no reason to take a look on the `host` / `parent` in this case because those can be standalone elements.