### PR TITLE
refactor(typography): only anchors with `href` should get hover underline

### DIFF
--- a/typography.html
+++ b/typography.html
@@ -113,7 +113,7 @@
         text-decoration: none;
       }
 
-      a:hover {
+      a[href]:hover {
         text-decoration: underline;
       }
 


### PR DESCRIPTION
`href` is not a mandatory attribute. Underlining a linkless link is most of
the time probably misleading.