### PR TITLE
Remove BlinkMacSystemFont

### DIFF
--- a/typography.html
+++ b/typography.html
@@ -6,7 +6,7 @@
   <style>
     html {
       /* Font families */
-      --lumo-font-family: -apple-system, BlinkMacSystemFont, "Roboto", "Segoe UI", Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+      --lumo-font-family: -apple-system, "Roboto", "Segoe UI", Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
 
       /* Font sizes */
       --lumo-font-size-xxs: .75rem;


### PR DESCRIPTION
This can cause printing issues in multiple versions of Chrome. We supposedly fixed in 81, but Canary 83 is still showing problems, so it would be best to remove. See https://bugs.chromium.org/p/chromium/issues/detail?id=1018581

**Chrome Canary 83**
<img width="236" alt="ScreenShot 2020-03-26 at 10 18 42 AM" src="https://user-images.githubusercontent.com/1920405/77664320-1e040900-6f4c-11ea-80f7-a9b8a4f2f94b.png">