### PR TITLE
feat: expose style modules as css literals

### DIFF
--- a/badge.html
+++ b/badge.html
@@ -2,9 +2,28 @@
 <link rel="import" href="color.html">
 <link rel="import" href="typography.html">
 
+<!-- MAGI ADD START
+<link rel="import" href="../vaadin-themable-mixin/register-styles.html">
+<script>
+  /**
+   * @namespace Vaadin
+   */
+  window.Vaadin = window.Vaadin || {};
+
+  /**
+   * @namespace Vaadin.LumoStyles
+   */
+  window.Vaadin.LumoStyles = window.Vaadin.LumoStyles || {};
+
+  (function() {
+    const badge = Vaadin.css`
+MAGI ADD END -->
+
+<!-- MAGI REMOVE START -->
 <dom-module id="lumo-badge">
   <template>
     <style>
+      /* MAGI REMOVE END */
       [theme~="badge"] {
         display: inline-flex;
         align-items: center;
@@ -26,7 +45,12 @@
       /* Ensure proper vertical alignment */
       [theme~="badge"]::before {
         display: inline-block;
+        /* MAGI REMOVE START */
         content: "\2003";
+        /* MAGI REMOVE END */
+        /* MAGI ADD START
+        content: "\\2003";
+        MAGI ADD END */
         width: 0;
       }
 
@@ -154,6 +178,16 @@
         margin-left: -0.375em;
         margin-right: 0;
       }
+      /* MAGI REMOVE START */
     </style>
   </template>
 </dom-module>
+<!-- MAGI REMOVE END -->
+<!-- MAGI ADD START
+`;
+Vaadin.registerStyles('', badge, {moduleId: 'lumo-badge'});
+
+Vaadin.LumoStyles.badge = badge;
+})();
+</script>
+MAGI ADD END -->

--- a/badge.html
+++ b/badge.html
@@ -18,7 +18,6 @@
   (function() {
     const badge = Vaadin.css`
 MAGI ADD END -->
-
 <!-- MAGI REMOVE START -->
 <dom-module id="lumo-badge">
   <template>

--- a/badge.html
+++ b/badge.html
@@ -184,10 +184,10 @@ MAGI ADD END -->
 </dom-module>
 <!-- MAGI REMOVE END -->
 <!-- MAGI ADD START
-`;
-Vaadin.registerStyles('', badge, {moduleId: 'lumo-badge'});
+    `;
+    Vaadin.registerStyles('', badge, {moduleId: 'lumo-badge'});
 
-Vaadin.LumoStyles.badge = badge;
-})();
+    Vaadin.LumoStyles.badge = badge;
+  })();
 </script>
 MAGI ADD END -->

--- a/bower.json
+++ b/bower.json
@@ -42,7 +42,8 @@
   "dependencies": {
     "polymer": "Polymer/polymer#^2.0.0",
     "iron-icon": "polymerelements/iron-icon#^2.0.1",
-    "iron-iconset-svg": "polymerelements/iron-iconset-svg#^2.1.0"
+    "iron-iconset-svg": "polymerelements/iron-iconset-svg#^2.1.0",
+    "vaadin-themable-mixin": "^1.6.1"
   },
   "devDependencies": {
     "vaadin-button": "vaadin/vaadin-button#^2.1.0",

--- a/color.html
+++ b/color.html
@@ -284,7 +284,7 @@ MAGI ADD END -->
 <!-- MAGI REMOVE END -->
 <!-- MAGI ADD START
 `;
-Vaadin.registerStyles('', colorLegacy, {moduleId: 'lumo-color-legacy', include: 'lumo-color'});
+Vaadin.registerStyles('', colorLegacy, {moduleId: 'lumo-color-legacy', include: ['lumo-color']});
 
 Vaadin.LumoStyles.colorLegacy = colorLegacy;
 })();

--- a/color.html
+++ b/color.html
@@ -109,25 +109,8 @@ $tpl.innerHTML = `<custom-style><style>${colorBase.toString().replace(':host', '
 document.head.appendChild($tpl.content);
 
 Vaadin.LumoStyles.colorBase = colorBase;
-})();
-</script>
 
-MAGI ADD END -->
-
-<!-- MAGI ADD START
-<script>
-  /**
-   * @namespace Vaadin
-   */
-  window.Vaadin = window.Vaadin || {};
-
-  /**
-   * @namespace Vaadin.LumoStyles
-   */
-  window.Vaadin.LumoStyles = window.Vaadin.LumoStyles || {};
-
-  (function() {
-    const color = Vaadin.css`
+const color = Vaadin.css`
 MAGI ADD END -->
 
 <!-- MAGI REMOVE START -->
@@ -247,25 +230,8 @@ MAGI ADD END -->
 Vaadin.registerStyles('', color, {moduleId: 'lumo-color'});
 
 Vaadin.LumoStyles.color = color;
-})();
-</script>
-MAGI ADD END -->
 
-<!-- Only needed for IE11 when you want to use the dark palette inside the light palette -->
-<!-- MAGI ADD START
-<script>
-  /**
-   * @namespace Vaadin
-   */
-  window.Vaadin = window.Vaadin || {};
-
-  /**
-   * @namespace Vaadin.LumoStyles
-   */
-  window.Vaadin.LumoStyles = window.Vaadin.LumoStyles || {};
-
-  (function() {
-    const colorLegacy = Vaadin.css`
+const colorLegacy = Vaadin.css`
 MAGI ADD END -->
 
 <!-- MAGI REMOVE START -->

--- a/color.html
+++ b/color.html
@@ -112,7 +112,6 @@ MAGI ADD END -->
 
     const color = Vaadin.css`
 MAGI ADD END -->
-
 <!-- MAGI REMOVE START -->
 <dom-module id="lumo-color">
   <template>
@@ -233,7 +232,6 @@ MAGI ADD END -->
 
     const colorLegacy = Vaadin.css`
 MAGI ADD END -->
-
 <!-- MAGI REMOVE START -->
 <dom-module id="lumo-color-legacy">
   <template>

--- a/color.html
+++ b/color.html
@@ -103,14 +103,14 @@ MAGI ADD END -->
 </custom-style>
 <!-- MAGI REMOVE END -->
 <!-- MAGI ADD START
-`;
-const $tpl = document.createElement('template');
-$tpl.innerHTML = `<custom-style><style>${colorBase.toString().replace(':host', 'html')}</style></custom-style>`;
-document.head.appendChild($tpl.content);
+    `;
+    const $tpl = document.createElement('template');
+    $tpl.innerHTML = `<custom-style><style>${colorBase.toString().replace(':host', 'html')}</style></custom-style>`;
+    document.head.appendChild($tpl.content);
 
-Vaadin.LumoStyles.colorBase = colorBase;
+    Vaadin.LumoStyles.colorBase = colorBase;
 
-const color = Vaadin.css`
+    const color = Vaadin.css`
 MAGI ADD END -->
 
 <!-- MAGI REMOVE START -->
@@ -226,12 +226,12 @@ MAGI ADD END -->
 </dom-module>
 <!-- MAGI REMOVE END -->
 <!-- MAGI ADD START
-`;
-Vaadin.registerStyles('', color, {moduleId: 'lumo-color'});
+    `;
+    Vaadin.registerStyles('', color, {moduleId: 'lumo-color'});
 
-Vaadin.LumoStyles.color = color;
+    Vaadin.LumoStyles.color = color;
 
-const colorLegacy = Vaadin.css`
+    const colorLegacy = Vaadin.css`
 MAGI ADD END -->
 
 <!-- MAGI REMOVE START -->
@@ -249,10 +249,10 @@ MAGI ADD END -->
 </dom-module>
 <!-- MAGI REMOVE END -->
 <!-- MAGI ADD START
-`;
-Vaadin.registerStyles('', colorLegacy, {moduleId: 'lumo-color-legacy', include: ['lumo-color']});
+    `;
+    Vaadin.registerStyles('', colorLegacy, {moduleId: 'lumo-color-legacy', include: ['lumo-color']});
 
-Vaadin.LumoStyles.colorLegacy = colorLegacy;
-})();
+    Vaadin.LumoStyles.colorLegacy = colorLegacy;
+  })();
 </script>
 MAGI ADD END -->

--- a/color.html
+++ b/color.html
@@ -1,10 +1,33 @@
 <link rel="import" href="version.html">
+<!-- MAGI REMOVE START -->
 <link rel="import" href="../polymer/lib/elements/custom-style.html">
 <link rel="import" href="../polymer/lib/elements/dom-module.html">
+<!-- MAGI REMOVE END -->
+<link rel="import" href="../vaadin-themable-mixin/register-styles.html">
 
+<!-- MAGI ADD START
+<script>
+  /**
+   * @namespace Vaadin
+   */
+  window.Vaadin = window.Vaadin || {};
+
+  /**
+   * @namespace Vaadin.LumoStyles
+   */
+  window.Vaadin.LumoStyles = window.Vaadin.LumoStyles || {};
+
+  (function() {
+    const colorBase = Vaadin.css`
+MAGI ADD END -->
+<!-- MAGI REMOVE START -->
 <custom-style>
   <style>
     html {
+    /* MAGI REMOVE END */
+    /* MAGI ADD START
+    :host {
+      MAGI ADD END */
       /* Base (background) */
       --lumo-base-color: #FFF;
 
@@ -75,12 +98,43 @@
       --lumo-success-text-color: hsl(145, 100%, 32%);
       --lumo-success-contrast-color: #FFF;
     }
+    /* MAGI REMOVE START */
   </style>
 </custom-style>
+<!-- MAGI REMOVE END -->
+<!-- MAGI ADD START
+`;
+const $tpl = document.createElement('template');
+$tpl.innerHTML = `<custom-style><style>${colorBase.toString().replace(':host', 'html')}</style></custom-style>`;
+document.head.appendChild($tpl.content);
 
+Vaadin.LumoStyles.colorBase = colorBase;
+})();
+</script>
+
+MAGI ADD END -->
+
+<!-- MAGI ADD START
+<script>
+  /**
+   * @namespace Vaadin
+   */
+  window.Vaadin = window.Vaadin || {};
+
+  /**
+   * @namespace Vaadin.LumoStyles
+   */
+  window.Vaadin.LumoStyles = window.Vaadin.LumoStyles || {};
+
+  (function() {
+    const color = Vaadin.css`
+MAGI ADD END -->
+
+<!-- MAGI REMOVE START -->
 <dom-module id="lumo-color">
   <template>
     <style>
+      /* MAGI REMOVE END */
       [theme~="dark"] {
         /* Base (background) */
         --lumo-base-color: hsl(214, 35%, 21%);
@@ -183,18 +237,56 @@
         background-color: var(--lumo-contrast-10pct);
         border-radius: var(--lumo-border-radius-m);
       }
+      /* MAGI REMOVE START */
     </style>
   </template>
 </dom-module>
+<!-- MAGI REMOVE END -->
+<!-- MAGI ADD START
+`;
+Vaadin.registerStyles('', color, {moduleId: 'lumo-color'});
+
+Vaadin.LumoStyles.color = color;
+})();
+</script>
+MAGI ADD END -->
 
 <!-- Only needed for IE11 when you want to use the dark palette inside the light palette -->
+<!-- MAGI ADD START
+<script>
+  /**
+   * @namespace Vaadin
+   */
+  window.Vaadin = window.Vaadin || {};
+
+  /**
+   * @namespace Vaadin.LumoStyles
+   */
+  window.Vaadin.LumoStyles = window.Vaadin.LumoStyles || {};
+
+  (function() {
+    const colorLegacy = Vaadin.css`
+MAGI ADD END -->
+
+<!-- MAGI REMOVE START -->
 <dom-module id="lumo-color-legacy">
   <template>
     <style include="lumo-color">
+      /* MAGI REMOVE END */
       :host {
         color: var(--lumo-body-text-color) !important;
         background-color: var(--lumo-base-color) !important;
       }
+      /* MAGI REMOVE START */
     </style>
   </template>
 </dom-module>
+<!-- MAGI REMOVE END -->
+<!-- MAGI ADD START
+`;
+Vaadin.registerStyles('', colorLegacy, {moduleId: 'lumo-color-legacy', include: 'lumo-color'});
+
+Vaadin.LumoStyles.colorLegacy = colorLegacy;
+})();
+</script>
+MAGI ADD END -->

--- a/color.html
+++ b/color.html
@@ -1,11 +1,11 @@
 <link rel="import" href="version.html">
-<!-- MAGI REMOVE START -->
 <link rel="import" href="../polymer/lib/elements/custom-style.html">
+<!-- MAGI REMOVE START -->
 <link rel="import" href="../polymer/lib/elements/dom-module.html">
 <!-- MAGI REMOVE END -->
-<link rel="import" href="../vaadin-themable-mixin/register-styles.html">
 
 <!-- MAGI ADD START
+<link rel="import" href="../vaadin-themable-mixin/register-styles.html">
 <script>
   /**
    * @namespace Vaadin

--- a/mixins/field-button.html
+++ b/mixins/field-button.html
@@ -55,10 +55,10 @@ MAGI ADD END -->
 </dom-module>
 <!-- MAGI REMOVE END -->
 <!-- MAGI ADD START
-`;
-Vaadin.registerStyles('', fieldButton, {moduleId: 'lumo-field-button'});
+    `;
+    Vaadin.registerStyles('', fieldButton, {moduleId: 'lumo-field-button'});
 
-Vaadin.LumoStyles.fieldButton = fieldButton;
-})();
+    Vaadin.LumoStyles.fieldButton = fieldButton;
+  })();
 </script>
 MAGI ADD END -->

--- a/mixins/field-button.html
+++ b/mixins/field-button.html
@@ -3,9 +3,27 @@
 <link rel="import" href="../sizing.html">
 <link rel="import" href="../style.html">
 
+<!-- MAGI ADD START
+<link rel="import" href="../../vaadin-themable-mixin/register-styles.html">
+<script>
+  /**
+   * @namespace Vaadin
+   */
+  window.Vaadin = window.Vaadin || {};
+
+  /**
+   * @namespace Vaadin.LumoStyles
+   */
+  window.Vaadin.LumoStyles = window.Vaadin.LumoStyles || {};
+
+  (function() {
+    const fieldButton = Vaadin.css`
+MAGI ADD END -->
+<!-- MAGI REMOVE START -->
 <dom-module id="lumo-field-button">
   <template>
     <style>
+      /* MAGI REMOVE END */
       [part$="button"] {
         flex: none;
         width: 1em;
@@ -31,6 +49,16 @@
         font-family: "lumo-icons";
         display: block;
       }
+      /* MAGI REMOVE START */
     </style>
   </template>
 </dom-module>
+<!-- MAGI REMOVE END -->
+<!-- MAGI ADD START
+`;
+Vaadin.registerStyles('', fieldButton, {moduleId: 'lumo-field-button'});
+
+Vaadin.LumoStyles.fieldButton = fieldButton;
+})();
+</script>
+MAGI ADD END -->

--- a/mixins/menu-overlay.html
+++ b/mixins/menu-overlay.html
@@ -59,12 +59,12 @@ MAGI ADD END -->
 </dom-module>
 <!-- MAGI REMOVE END -->
 <!-- MAGI ADD START
-`;
-Vaadin.registerStyles('', menuOverlayCore, {moduleId: 'lumo-menu-overlay-core'});
+    `;
+    Vaadin.registerStyles('', menuOverlayCore, {moduleId: 'lumo-menu-overlay-core'});
 
-Vaadin.LumoStyles.menuOverlayCore = menuOverlayCore;
+    Vaadin.LumoStyles.menuOverlayCore = menuOverlayCore;
 
-const menuOverlay = Vaadin.css`
+    const menuOverlay = Vaadin.css`
 MAGI ADD END -->
 <!-- MAGI REMOVE START -->
 <dom-module id="lumo-menu-overlay">
@@ -138,10 +138,10 @@ MAGI ADD END -->
 </dom-module>
 <!-- MAGI REMOVE END -->
 <!-- MAGI ADD START
-`;
-Vaadin.registerStyles('', menuOverlay, {moduleId: 'lumo-menu-overlay', include: ['lumo-overlay', 'lumo-menu-overlay-core']});
+    `;
+    Vaadin.registerStyles('', menuOverlay, {moduleId: 'lumo-menu-overlay', include: ['lumo-overlay', 'lumo-menu-overlay-core']});
 
-Vaadin.LumoStyles.menuOverlay = menuOverlay;
-})();
+    Vaadin.LumoStyles.menuOverlay = menuOverlay;
+  })();
 </script>
 MAGI ADD END -->

--- a/mixins/menu-overlay.html
+++ b/mixins/menu-overlay.html
@@ -3,9 +3,27 @@
 <link rel="import" href="overlay.html">
 
 <!-- Split as a separate module because combo box can only use the "fullscreen" styles -->
+<!-- MAGI ADD START
+<link rel="import" href="../../vaadin-themable-mixin/register-styles.html">
+<script>
+  /**
+   * @namespace Vaadin
+   */
+  window.Vaadin = window.Vaadin || {};
+
+  /**
+   * @namespace Vaadin.LumoStyles
+   */
+  window.Vaadin.LumoStyles = window.Vaadin.LumoStyles || {};
+
+  (function() {
+    const menuOverlayCore = Vaadin.css`
+MAGI ADD END -->
+<!-- MAGI REMOVE START -->
 <dom-module id="lumo-menu-overlay-core">
   <template>
     <style>
+      /* MAGI REMOVE END */
       :host([opening]),
       :host([closing]) {
         animation: 0.14s lumo-overlay-dummy-animation;
@@ -35,15 +53,26 @@
           opacity: 0;
         }
       }
+      /* MAGI REMOVE START */
     </style>
   </template>
 </dom-module>
+<!-- MAGI REMOVE END -->
+<!-- MAGI ADD START
+`;
+Vaadin.registerStyles('', menuOverlayCore, {moduleId: 'lumo-menu-overlay-core'});
 
+Vaadin.LumoStyles.menuOverlayCore = menuOverlayCore;
+
+const menuOverlay = Vaadin.css`
+MAGI ADD END -->
+<!-- MAGI REMOVE START -->
 <dom-module id="lumo-menu-overlay">
   <template>
     <style include="lumo-overlay lumo-menu-overlay-core">
+      /* MAGI REMOVE END */
       /* Small viewport (bottom sheet) styles */
-      /* Use direct media queries instead of the state attributes (`[phone]` and `[fullscreen]`) provided by the elements */
+      /* Use direct media queries instead of the state attributes ([phone] and [fullscreen]) provided by the elements */
       @media (max-width: 420px), (max-height: 420px) {
         :host {
           top: 0 !important;
@@ -103,6 +132,16 @@
           transform: translateY(150%);
         }
       }
+      /* MAGI REMOVE START */
     </style>
   </template>
 </dom-module>
+<!-- MAGI REMOVE END -->
+<!-- MAGI ADD START
+`;
+Vaadin.registerStyles('', menuOverlay, {moduleId: 'lumo-menu-overlay', include: ['lumo-overlay', 'lumo-menu-overlay-core']});
+
+Vaadin.LumoStyles.menuOverlay = menuOverlay;
+})();
+</script>
+MAGI ADD END -->

--- a/mixins/overlay.html
+++ b/mixins/overlay.html
@@ -3,9 +3,27 @@
 <link rel="import" href="../style.html">
 <link rel="import" href="../typography.html">
 
+<!-- MAGI ADD START
+<link rel="import" href="../../vaadin-themable-mixin/register-styles.html">
+<script>
+  /**
+   * @namespace Vaadin
+   */
+  window.Vaadin = window.Vaadin || {};
+
+  /**
+   * @namespace Vaadin.LumoStyles
+   */
+  window.Vaadin.LumoStyles = window.Vaadin.LumoStyles || {};
+
+  (function() {
+    const overlay = Vaadin.css`
+MAGI ADD END -->
+<!-- MAGI REMOVE START -->
 <dom-module id="lumo-overlay">
   <template>
     <style>
+      /* MAGI REMOVE END */
       :host {
         top: var(--lumo-space-m);
         right: var(--lumo-space-m);
@@ -63,6 +81,16 @@
         0% { opacity: 1; }
         100% { opacity: 1; }
       }
+      /* MAGI REMOVE START */
     </style>
   </template>
 </dom-module>
+<!-- MAGI REMOVE END -->
+<!-- MAGI ADD START
+`;
+Vaadin.registerStyles('', overlay, {moduleId: 'lumo-overlay'});
+
+Vaadin.LumoStyles.overlay = overlay;
+})();
+</script>
+MAGI ADD END -->

--- a/mixins/overlay.html
+++ b/mixins/overlay.html
@@ -87,10 +87,10 @@ MAGI ADD END -->
 </dom-module>
 <!-- MAGI REMOVE END -->
 <!-- MAGI ADD START
-`;
-Vaadin.registerStyles('', overlay, {moduleId: 'lumo-overlay'});
+    `;
+    Vaadin.registerStyles('', overlay, {moduleId: 'lumo-overlay'});
 
-Vaadin.LumoStyles.overlay = overlay;
-})();
+    Vaadin.LumoStyles.overlay = overlay;
+  })();
 </script>
 MAGI ADD END -->

--- a/mixins/required-field.html
+++ b/mixins/required-field.html
@@ -122,10 +122,10 @@ MAGI ADD END -->
 </dom-module>
 <!-- MAGI REMOVE END -->
 <!-- MAGI ADD START
-`;
-Vaadin.registerStyles('', requiredField, {moduleId: 'lumo-required-field'});
+    `;
+    Vaadin.registerStyles('', requiredField, {moduleId: 'lumo-required-field'});
 
-Vaadin.LumoStyles.requiredField = requiredField;
-})();
+    Vaadin.LumoStyles.requiredField = requiredField;
+  })();
 </script>
 MAGI ADD END -->

--- a/mixins/required-field.html
+++ b/mixins/required-field.html
@@ -3,9 +3,27 @@
 <link rel="import" href="../style.html">
 <link rel="import" href="../typography.html">
 
+<!-- MAGI ADD START
+<link rel="import" href="../../vaadin-themable-mixin/register-styles.html">
+<script>
+  /**
+   * @namespace Vaadin
+   */
+  window.Vaadin = window.Vaadin || {};
+
+  /**
+   * @namespace Vaadin.LumoStyles
+   */
+  window.Vaadin.LumoStyles = window.Vaadin.LumoStyles || {};
+
+  (function() {
+    const requiredField = Vaadin.css`
+MAGI ADD END -->
+<!-- MAGI REMOVE START -->
 <dom-module id="lumo-required-field">
   <template>
     <style>
+      /* MAGI REMOVE END */
       [part="label"] {
         align-self: flex-start;
         color: var(--lumo-secondary-text-color);
@@ -98,7 +116,16 @@
         margin-left: 0;
         margin-right: calc(var(--lumo-border-radius-m) / 4);
       }
-
+      /* MAGI REMOVE START */
     </style>
   </template>
 </dom-module>
+<!-- MAGI REMOVE END -->
+<!-- MAGI ADD START
+`;
+Vaadin.registerStyles('', requiredField, {moduleId: 'lumo-required-field'});
+
+Vaadin.LumoStyles.requiredField = requiredField;
+})();
+</script>
+MAGI ADD END -->

--- a/sizing.html
+++ b/sizing.html
@@ -1,9 +1,32 @@
 <link rel="import" href="version.html">
+<!-- MAGI REMOVE START -->
 <link rel="import" href="../polymer/lib/elements/custom-style.html">
+<!-- MAGI REMOVE END -->
+<link rel="import" href="../vaadin-themable-mixin/register-styles.html">
 
+<!-- MAGI ADD START
+<script>
+  /**
+   * @namespace Vaadin
+   */
+  window.Vaadin = window.Vaadin || {};
+
+  /**
+   * @namespace Vaadin.LumoStyles
+   */
+  window.Vaadin.LumoStyles = window.Vaadin.LumoStyles || {};
+
+  (function() {
+    const sizing = Vaadin.css`
+MAGI ADD END -->
+<!-- MAGI REMOVE START -->
 <custom-style>
   <style>
     html {
+    /* MAGI REMOVE END */
+    /* MAGI ADD START
+    :host {
+      MAGI ADD END */
       --lumo-size-xs: 1.625rem;
       --lumo-size-s: 1.875rem;
       --lumo-size-m: 2.25rem;
@@ -17,5 +40,17 @@
       /* For backwards compatibility */
       --lumo-icon-size: var(--lumo-icon-size-m);
     }
+    /* MAGI REMOVE START */
   </style>
 </custom-style>
+<!-- MAGI REMOVE END -->
+<!-- MAGI ADD START
+`;
+const $tpl = document.createElement('template');
+$tpl.innerHTML = `<custom-style><style>${sizing.toString().replace(':host', 'html')}</style></custom-style>`;
+document.head.appendChild($tpl.content);
+
+Vaadin.LumoStyles.sizing = sizing;
+})();
+</script>
+MAGI ADD END -->

--- a/sizing.html
+++ b/sizing.html
@@ -1,10 +1,8 @@
 <link rel="import" href="version.html">
-<!-- MAGI REMOVE START -->
 <link rel="import" href="../polymer/lib/elements/custom-style.html">
-<!-- MAGI REMOVE END -->
-<link rel="import" href="../vaadin-themable-mixin/register-styles.html">
 
 <!-- MAGI ADD START
+<link rel="import" href="../vaadin-themable-mixin/register-styles.html">
 <script>
   /**
    * @namespace Vaadin

--- a/sizing.html
+++ b/sizing.html
@@ -43,12 +43,12 @@ MAGI ADD END -->
 </custom-style>
 <!-- MAGI REMOVE END -->
 <!-- MAGI ADD START
-`;
-const $tpl = document.createElement('template');
-$tpl.innerHTML = `<custom-style><style>${sizing.toString().replace(':host', 'html')}</style></custom-style>`;
-document.head.appendChild($tpl.content);
+    `;
+    const $tpl = document.createElement('template');
+    $tpl.innerHTML = `<custom-style><style>${sizing.toString().replace(':host', 'html')}</style></custom-style>`;
+    document.head.appendChild($tpl.content);
 
-Vaadin.LumoStyles.sizing = sizing;
-})();
+    Vaadin.LumoStyles.sizing = sizing;
+  })();
 </script>
 MAGI ADD END -->

--- a/spacing.html
+++ b/spacing.html
@@ -51,12 +51,12 @@ MAGI ADD END -->
 </custom-style>
 <!-- MAGI REMOVE END -->
 <!-- MAGI ADD START
-`;
-const $tpl = document.createElement('template');
-$tpl.innerHTML = `<custom-style><style>${spacing.toString().replace(':host', 'html')}</style></custom-style>`;
-document.head.appendChild($tpl.content);
+    `;
+    const $tpl = document.createElement('template');
+    $tpl.innerHTML = `<custom-style><style>${spacing.toString().replace(':host', 'html')}</style></custom-style>`;
+    document.head.appendChild($tpl.content);
 
-Vaadin.LumoStyles.spacing = spacing;
-})();
+    Vaadin.LumoStyles.spacing = spacing;
+  })();
 </script>
 MAGI ADD END -->

--- a/spacing.html
+++ b/spacing.html
@@ -1,10 +1,8 @@
 <link rel="import" href="version.html">
-<!-- MAGI REMOVE START -->
 <link rel="import" href="../polymer/lib/elements/custom-style.html">
-<!-- MAGI REMOVE END -->
-<link rel="import" href="../vaadin-themable-mixin/register-styles.html">
 
 <!-- MAGI ADD START
+<link rel="import" href="../vaadin-themable-mixin/register-styles.html">
 <script>
   /**
    * @namespace Vaadin

--- a/spacing.html
+++ b/spacing.html
@@ -1,9 +1,32 @@
 <link rel="import" href="version.html">
+<!-- MAGI REMOVE START -->
 <link rel="import" href="../polymer/lib/elements/custom-style.html">
+<!-- MAGI REMOVE END -->
+<link rel="import" href="../vaadin-themable-mixin/register-styles.html">
 
+<!-- MAGI ADD START
+<script>
+  /**
+   * @namespace Vaadin
+   */
+  window.Vaadin = window.Vaadin || {};
+
+  /**
+   * @namespace Vaadin.LumoStyles
+   */
+  window.Vaadin.LumoStyles = window.Vaadin.LumoStyles || {};
+
+  (function() {
+    const spacing = Vaadin.css`
+MAGI ADD END -->
+<!-- MAGI REMOVE START -->
 <custom-style>
   <style>
     html {
+    /* MAGI REMOVE END */
+    /* MAGI ADD START
+    :host {
+      MAGI ADD END */
       /* Square */
       --lumo-space-xs: 0.25rem;
       --lumo-space-s: 0.5rem;
@@ -25,5 +48,17 @@
       --lumo-space-tall-l: var(--lumo-space-l) calc(var(--lumo-space-l) / 2);
       --lumo-space-tall-xl: var(--lumo-space-xl) calc(var(--lumo-space-xl) / 2);
     }
+    /* MAGI REMOVE START */
   </style>
 </custom-style>
+<!-- MAGI REMOVE END -->
+<!-- MAGI ADD START
+`;
+const $tpl = document.createElement('template');
+$tpl.innerHTML = `<custom-style><style>${spacing.toString().replace(':host', 'html')}</style></custom-style>`;
+document.head.appendChild($tpl.content);
+
+Vaadin.LumoStyles.spacing = spacing;
+})();
+</script>
+MAGI ADD END -->

--- a/style.html
+++ b/style.html
@@ -1,9 +1,32 @@
 <link rel="import" href="version.html">
+<!-- MAGI REMOVE START -->
 <link rel="import" href="../polymer/lib/elements/custom-style.html">
+<!-- MAGI REMOVE END -->
+<link rel="import" href="../vaadin-themable-mixin/register-styles.html">
 
+<!-- MAGI ADD START
+<script>
+  /**
+   * @namespace Vaadin
+   */
+  window.Vaadin = window.Vaadin || {};
+
+  /**
+   * @namespace Vaadin.LumoStyles
+   */
+  window.Vaadin.LumoStyles = window.Vaadin.LumoStyles || {};
+
+  (function() {
+    const style = Vaadin.css`
+MAGI ADD END -->
+<!-- MAGI REMOVE START -->
 <custom-style>
   <style>
     html {
+    /* MAGI REMOVE END */
+    /* MAGI ADD START
+    :host {
+      MAGI ADD END */
       /* Border radius */
       --lumo-border-radius-s: 0.25em; /* Checkbox, badge, date-picker year indicator, etc */
       --lumo-border-radius-m: var(--lumo-border-radius, 0.25em); /* Button, text field, menu overlay, etc */
@@ -20,5 +43,17 @@
       /* Clickable element cursor */
       --lumo-clickable-cursor: default;
     }
+    /* MAGI REMOVE START */
   </style>
 </custom-style>
+<!-- MAGI REMOVE END -->
+<!-- MAGI ADD START
+`;
+const $tpl = document.createElement('template');
+$tpl.innerHTML = `<custom-style><style>${style.toString().replace(':host', 'html')}</style></custom-style>`;
+document.head.appendChild($tpl.content);
+
+Vaadin.LumoStyles.style = style;
+})();
+</script>
+MAGI ADD END -->

--- a/style.html
+++ b/style.html
@@ -46,12 +46,12 @@ MAGI ADD END -->
 </custom-style>
 <!-- MAGI REMOVE END -->
 <!-- MAGI ADD START
-`;
-const $tpl = document.createElement('template');
-$tpl.innerHTML = `<custom-style><style>${style.toString().replace(':host', 'html')}</style></custom-style>`;
-document.head.appendChild($tpl.content);
+    `;
+    const $tpl = document.createElement('template');
+    $tpl.innerHTML = `<custom-style><style>${style.toString().replace(':host', 'html')}</style></custom-style>`;
+    document.head.appendChild($tpl.content);
 
-Vaadin.LumoStyles.style = style;
-})();
+    Vaadin.LumoStyles.style = style;
+  })();
 </script>
 MAGI ADD END -->

--- a/style.html
+++ b/style.html
@@ -1,10 +1,8 @@
 <link rel="import" href="version.html">
-<!-- MAGI REMOVE START -->
 <link rel="import" href="../polymer/lib/elements/custom-style.html">
-<!-- MAGI REMOVE END -->
-<link rel="import" href="../vaadin-themable-mixin/register-styles.html">
 
 <!-- MAGI ADD START
+<link rel="import" href="../vaadin-themable-mixin/register-styles.html">
 <script>
   /**
    * @namespace Vaadin

--- a/typography.html
+++ b/typography.html
@@ -57,24 +57,8 @@ $tpl.innerHTML = `<custom-style><style>${font.toString().replace(':host', 'html'
 document.head.appendChild($tpl.content);
 
 Vaadin.LumoStyles.font = font;
-})();
-</script>
-MAGI ADD END -->
 
-<!-- MAGI ADD START
-<script>
-  /**
-   * @namespace Vaadin
-   */
-  window.Vaadin = window.Vaadin || {};
-
-  /**
-   * @namespace Vaadin.LumoStyles
-   */
-  window.Vaadin.LumoStyles = window.Vaadin.LumoStyles || {};
-
-  (function() {
-    const typography = Vaadin.css`
+const typography = Vaadin.css`
 MAGI ADD END -->
 
 <!-- MAGI REMOVE START -->

--- a/typography.html
+++ b/typography.html
@@ -1,11 +1,11 @@
 <link rel="import" href="version.html">
-<!-- MAGI REMOVE START -->
 <link rel="import" href="../polymer/lib/elements/custom-style.html">
+<!-- MAGI REMOVE START -->
 <link rel="import" href="../polymer/lib/elements/dom-module.html">
 <!-- MAGI REMOVE END -->
-<link rel="import" href="../vaadin-themable-mixin/register-styles.html">
 
 <!-- MAGI ADD START
+<link rel="import" href="../vaadin-themable-mixin/register-styles.html">
 <script>
   /**
    * @namespace Vaadin

--- a/typography.html
+++ b/typography.html
@@ -60,7 +60,6 @@ MAGI ADD END -->
 
     const typography = Vaadin.css`
 MAGI ADD END -->
-
 <!-- MAGI REMOVE START -->
 <dom-module id="lumo-typography">
   <template>

--- a/typography.html
+++ b/typography.html
@@ -51,14 +51,14 @@ MAGI ADD END -->
 </custom-style>
 <!-- MAGI REMOVE END -->
 <!-- MAGI ADD START
-`;
-const $tpl = document.createElement('template');
-$tpl.innerHTML = `<custom-style><style>${font.toString().replace(':host', 'html')}</style></custom-style>`;
-document.head.appendChild($tpl.content);
+    `;
+    const $tpl = document.createElement('template');
+    $tpl.innerHTML = `<custom-style><style>${font.toString().replace(':host', 'html')}</style></custom-style>`;
+    document.head.appendChild($tpl.content);
 
-Vaadin.LumoStyles.font = font;
+    Vaadin.LumoStyles.font = font;
 
-const typography = Vaadin.css`
+    const typography = Vaadin.css`
 MAGI ADD END -->
 
 <!-- MAGI REMOVE START -->
@@ -182,12 +182,12 @@ MAGI ADD END -->
     </style>
   </template>
 </dom-module>
-<!-- MAGI REMOVE END -->
-<!-- MAGI ADD START
-`;
-Vaadin.registerStyles('', typography, {moduleId: 'lumo-typography'});
+    <!-- MAGI REMOVE END -->
+    <!-- MAGI ADD START
+    `;
+    Vaadin.registerStyles('', typography, {moduleId: 'lumo-typography'});
 
-Vaadin.LumoStyles.typography = typography;
-})();
+    Vaadin.LumoStyles.typography = typography;
+  })();
 </script>
 MAGI ADD END -->

--- a/typography.html
+++ b/typography.html
@@ -1,10 +1,33 @@
 <link rel="import" href="version.html">
+<!-- MAGI REMOVE START -->
 <link rel="import" href="../polymer/lib/elements/custom-style.html">
 <link rel="import" href="../polymer/lib/elements/dom-module.html">
+<!-- MAGI REMOVE END -->
+<link rel="import" href="../vaadin-themable-mixin/register-styles.html">
 
+<!-- MAGI ADD START
+<script>
+  /**
+   * @namespace Vaadin
+   */
+  window.Vaadin = window.Vaadin || {};
+
+  /**
+   * @namespace Vaadin.LumoStyles
+   */
+  window.Vaadin.LumoStyles = window.Vaadin.LumoStyles || {};
+
+  (function() {
+    const font = Vaadin.css`
+MAGI ADD END -->
+<!-- MAGI REMOVE START -->
 <custom-style>
   <style>
     html {
+    /* MAGI REMOVE END */
+    /* MAGI ADD START
+    :host {
+      MAGI ADD END */
       /* Font families */
       --lumo-font-family: -apple-system, BlinkMacSystemFont, "Roboto", "Segoe UI", Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
 
@@ -23,13 +46,42 @@
       --lumo-line-height-s: 1.375;
       --lumo-line-height-m: 1.625;
     }
-
+    /* MAGI REMOVE START */
   </style>
 </custom-style>
+<!-- MAGI REMOVE END -->
+<!-- MAGI ADD START
+`;
+const $tpl = document.createElement('template');
+$tpl.innerHTML = `<custom-style><style>${font.toString().replace(':host', 'html')}</style></custom-style>`;
+document.head.appendChild($tpl.content);
 
+Vaadin.LumoStyles.font = font;
+})();
+</script>
+MAGI ADD END -->
+
+<!-- MAGI ADD START
+<script>
+  /**
+   * @namespace Vaadin
+   */
+  window.Vaadin = window.Vaadin || {};
+
+  /**
+   * @namespace Vaadin.LumoStyles
+   */
+  window.Vaadin.LumoStyles = window.Vaadin.LumoStyles || {};
+
+  (function() {
+    const typography = Vaadin.css`
+MAGI ADD END -->
+
+<!-- MAGI REMOVE START -->
 <dom-module id="lumo-typography">
   <template>
     <style>
+      /* MAGI REMOVE END */
       html {
         font-family: var(--lumo-font-family);
         font-size: var(--lumo-font-size, var(--lumo-font-size-m));
@@ -142,7 +194,16 @@
         border-left: none;
         border-right: 2px solid var(--lumo-contrast-30pct);
       }
-
+      /* MAGI REMOVE START */
     </style>
   </template>
 </dom-module>
+<!-- MAGI REMOVE END -->
+<!-- MAGI ADD START
+`;
+Vaadin.registerStyles('', typography, {moduleId: 'lumo-typography'});
+
+Vaadin.LumoStyles.typography = typography;
+})();
+</script>
+MAGI ADD END -->


### PR DESCRIPTION
Fixes #90 

This is a PR to test a possible way of shipping `css` tagged literals, which use `lit-element` for Polymer 3 version.
To check it locally, remember to remove `bower_components/vaadin-lumo-styles` before running `magi p3-convert`.

Converted output:

<details>
<summary>badge.js</summary>

```js
import './style.js';
import './color.js';
import './typography.js';
import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/register-styles.js';
const badge = css`

  [theme~="badge"] {
    display: inline-flex;
    align-items: center;
    justify-content: center;
    box-sizing: border-box;
    padding: 0.4em calc(0.5em + var(--lumo-border-radius-s) / 4);
    color: var(--lumo-primary-text-color);
    background-color: var(--lumo-primary-color-10pct);
    border-radius: var(--lumo-border-radius-s);
    font-family: var(--lumo-font-family);
    font-size: var(--lumo-font-size-s);
    line-height: 1;
    font-weight: 500;
    text-transform: initial;
    letter-spacing: initial;
    min-width: calc(var(--lumo-line-height-xs) * 1em + 0.45em);
  }

  /* Ensure proper vertical alignment */
  [theme~="badge"]::before {
    display: inline-block;
    content: "\\2003";
    width: 0;
  }

  [theme~="badge"][theme~="small"] {
    font-size: var(--lumo-font-size-xxs);
    line-height: 1;
  }

  /* Colors */

  [theme~="badge"][theme~="success"] {
    color: var(--lumo-success-text-color);
    background-color: var(--lumo-success-color-10pct);
  }

  [theme~="badge"][theme~="error"] {
    color: var(--lumo-error-text-color);
    background-color: var(--lumo-error-color-10pct);
  }

  [theme~="badge"][theme~="contrast"] {
    color: var(--lumo-contrast-80pct);
    background-color: var(--lumo-contrast-5pct);
  }

  /* Primary */

  [theme~="badge"][theme~="primary"] {
    color: var(--lumo-primary-contrast-color);
    background-color: var(--lumo-primary-color);
  }

  [theme~="badge"][theme~="success"][theme~="primary"] {
    color: var(--lumo-success-contrast-color);
    background-color: var(--lumo-success-color);
  }

  [theme~="badge"][theme~="error"][theme~="primary"] {
    color: var(--lumo-error-contrast-color);
    background-color: var(--lumo-error-color);
  }

  [theme~="badge"][theme~="contrast"][theme~="primary"] {
    color: var(--lumo-base-color);
    background-color: var(--lumo-contrast);
  }

  /* Links */

  [theme~="badge"][href]:hover {
    text-decoration: none;
  }

  /* Icon */

  [theme~="badge"] iron-icon {
    margin: -0.25em 0;
    --iron-icon-width: 1.5em;
    --iron-icon-height: 1.5em;
  }

  [theme~="badge"] iron-icon:first-child {
    margin-left: -0.375em;
  }

  [theme~="badge"] iron-icon:last-child {
    margin-right: -0.375em;
  }

  [theme~="badge"][icon] {
    min-width: 0;
    padding: 0;
    font-size: 1rem;
    --iron-icon-width: var(--lumo-icon-size-m);
    --iron-icon-height: var(--lumo-icon-size-m);
  }

  [theme~="badge"][icon][theme~="small"] {
    --iron-icon-width: var(--lumo-icon-size-s);
    --iron-icon-height: var(--lumo-icon-size-s);
  }

  /* Empty */

  [theme~="badge"]:not([icon]):empty {
    min-width: 0;
    width: 1em;
    height: 1em;
    padding: 0;
    border-radius: 50%;
    background-color: var(--lumo-primary-color);
  }

  [theme~="badge"][theme~="small"]:not([icon]):empty {
    width: 0.75em;
    height: 0.75em;
  }

  [theme~="badge"][theme~="contrast"]:not([icon]):empty {
    background-color: var(--lumo-contrast);
  }

  [theme~="badge"][theme~="success"]:not([icon]):empty {
    background-color: var(--lumo-success-color);
  }

  [theme~="badge"][theme~="error"]:not([icon]):empty {
    background-color: var(--lumo-error-color);
  }

  /* Pill */

  [theme~="badge"][theme~="pill"] {
    --lumo-border-radius-s: 1em;
  }

  /* RTL specific styles */

  [dir="rtl"][theme~="badge"] iron-icon:first-child {
    margin-right: -0.375em;
    margin-left: 0;
  }

  [dir="rtl"][theme~="badge"] iron-icon:last-child {
    margin-left: -0.375em;
    margin-right: 0;
  }
`;
registerStyles('', badge, {moduleId: 'lumo-badge'});

export { badge };
```
</details>


<details>
<summary>color.js</summary>

```js
import './version.js';
import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/register-styles.js';
const colorBase = css`
:host {
  /* Base (background) */
  --lumo-base-color: #FFF;

  /* Tint */
  --lumo-tint-5pct: hsla(0, 0%, 100%, 0.3);
  --lumo-tint-10pct: hsla(0, 0%, 100%, 0.37);
  --lumo-tint-20pct: hsla(0, 0%, 100%, 0.44);
  --lumo-tint-30pct: hsla(0, 0%, 100%, 0.5);
  --lumo-tint-40pct: hsla(0, 0%, 100%, 0.57);
  --lumo-tint-50pct: hsla(0, 0%, 100%, 0.64);
  --lumo-tint-60pct: hsla(0, 0%, 100%, 0.7);
  --lumo-tint-70pct: hsla(0, 0%, 100%, 0.77);
  --lumo-tint-80pct: hsla(0, 0%, 100%, 0.84);
  --lumo-tint-90pct: hsla(0, 0%, 100%, 0.9);
  --lumo-tint: #FFF;

  /* Shade */
  --lumo-shade-5pct: hsla(214, 61%, 25%, 0.05);
  --lumo-shade-10pct: hsla(214, 57%, 24%, 0.1);
  --lumo-shade-20pct: hsla(214, 53%, 23%, 0.16);
  --lumo-shade-30pct: hsla(214, 50%, 22%, 0.26);
  --lumo-shade-40pct: hsla(214, 47%, 21%, 0.38);
  --lumo-shade-50pct: hsla(214, 45%, 20%, 0.5);
  --lumo-shade-60pct: hsla(214, 43%, 19%, 0.61);
  --lumo-shade-70pct: hsla(214, 42%, 18%, 0.72);
  --lumo-shade-80pct: hsla(214, 41%, 17%, 0.83);
  --lumo-shade-90pct: hsla(214, 40%, 16%, 0.94);
  --lumo-shade: hsl(214, 35%, 15%);

  /* Contrast */
  --lumo-contrast-5pct: var(--lumo-shade-5pct);
  --lumo-contrast-10pct: var(--lumo-shade-10pct);
  --lumo-contrast-20pct: var(--lumo-shade-20pct);
  --lumo-contrast-30pct: var(--lumo-shade-30pct);
  --lumo-contrast-40pct: var(--lumo-shade-40pct);
  --lumo-contrast-50pct: var(--lumo-shade-50pct);
  --lumo-contrast-60pct: var(--lumo-shade-60pct);
  --lumo-contrast-70pct: var(--lumo-shade-70pct);
  --lumo-contrast-80pct: var(--lumo-shade-80pct);
  --lumo-contrast-90pct: var(--lumo-shade-90pct);
  --lumo-contrast: var(--lumo-shade);

  /* Text */
  --lumo-header-text-color: var(--lumo-contrast);
  --lumo-body-text-color: var(--lumo-contrast-90pct);
  --lumo-secondary-text-color: var(--lumo-contrast-70pct);
  --lumo-tertiary-text-color: var(--lumo-contrast-50pct);
  --lumo-disabled-text-color: var(--lumo-contrast-30pct);

  /* Primary */
  --lumo-primary-color: hsl(214, 90%, 52%);
  --lumo-primary-color-50pct: hsla(214, 90%, 52%, 0.5);
  --lumo-primary-color-10pct: hsla(214, 90%, 52%, 0.1);
  --lumo-primary-text-color: var(--lumo-primary-color);
  --lumo-primary-contrast-color: #FFF;

  /* Error */
  --lumo-error-color: hsl(3, 100%, 61%);
  --lumo-error-color-50pct: hsla(3, 100%, 60%, 0.5);
  --lumo-error-color-10pct: hsla(3, 100%, 60%, 0.1);
  --lumo-error-text-color: hsl(3, 92%, 53%);
  --lumo-error-contrast-color: #FFF;

  /* Success */
  --lumo-success-color: hsl(145, 80%, 42%); /* hsl(144,82%,37%); */
  --lumo-success-color-50pct: hsla(145, 76%, 44%, 0.55);
  --lumo-success-color-10pct: hsla(145, 76%, 44%, 0.12);
  --lumo-success-text-color: hsl(145, 100%, 32%);
  --lumo-success-contrast-color: #FFF;
}
`;
const $tpl = document.createElement('template');
$tpl.innerHTML = `<custom-style><style>${colorBase.toString().replace(':host', 'html')}</style></custom-style>`;
document.head.appendChild($tpl.content);

export { colorBase };
const color = css`

  [theme~="dark"] {
    /* Base (background) */
    --lumo-base-color: hsl(214, 35%, 21%);

    /* Tint */
    --lumo-tint-5pct: hsla(214, 65%, 85%, 0.06);
    --lumo-tint-10pct: hsla(214, 60%, 80%, 0.14);
    --lumo-tint-20pct: hsla(214, 64%, 82%, 0.23);
    --lumo-tint-30pct: hsla(214, 69%, 84%, 0.32);
    --lumo-tint-40pct: hsla(214, 73%, 86%, 0.41);
    --lumo-tint-50pct: hsla(214, 78%, 88%, 0.5);
    --lumo-tint-60pct: hsla(214, 82%, 90%, 0.6);
    --lumo-tint-70pct: hsla(214, 87%, 92%, 0.7);
    --lumo-tint-80pct: hsla(214, 91%, 94%, 0.8);
    --lumo-tint-90pct: hsla(214, 96%, 96%, 0.9);
    --lumo-tint: hsl(214, 100%, 98%);

    /* Shade */
    --lumo-shade-5pct: hsla(214, 0%, 0%, 0.07);
    --lumo-shade-10pct: hsla(214, 4%, 2%, 0.15);
    --lumo-shade-20pct: hsla(214, 8%, 4%, 0.23);
    --lumo-shade-30pct: hsla(214, 12%, 6%, 0.32);
    --lumo-shade-40pct: hsla(214, 16%, 8%, 0.41);
    --lumo-shade-50pct: hsla(214, 20%, 10%, 0.5);
    --lumo-shade-60pct: hsla(214, 24%, 12%, 0.6);
    --lumo-shade-70pct: hsla(214, 28%, 13%, 0.7);
    --lumo-shade-80pct: hsla(214, 32%, 13%, 0.8);
    --lumo-shade-90pct: hsla(214, 33%, 13%, 0.9);
    --lumo-shade: hsl(214, 33%, 13%);

    /* Contrast */
    --lumo-contrast-5pct: var(--lumo-tint-5pct);
    --lumo-contrast-10pct: var(--lumo-tint-10pct);
    --lumo-contrast-20pct: var(--lumo-tint-20pct);
    --lumo-contrast-30pct: var(--lumo-tint-30pct);
    --lumo-contrast-40pct: var(--lumo-tint-40pct);
    --lumo-contrast-50pct: var(--lumo-tint-50pct);
    --lumo-contrast-60pct: var(--lumo-tint-60pct);
    --lumo-contrast-70pct: var(--lumo-tint-70pct);
    --lumo-contrast-80pct: var(--lumo-tint-80pct);
    --lumo-contrast-90pct: var(--lumo-tint-90pct);
    --lumo-contrast: var(--lumo-tint);

    /* Text */
    --lumo-header-text-color: var(--lumo-contrast);
    --lumo-body-text-color: var(--lumo-contrast-90pct);
    --lumo-secondary-text-color: var(--lumo-contrast-70pct);
    --lumo-tertiary-text-color: var(--lumo-contrast-50pct);
    --lumo-disabled-text-color: var(--lumo-contrast-30pct);

    /* Primary */
    --lumo-primary-color: hsl(214, 86%, 55%);
    --lumo-primary-color-50pct: hsla(214, 86%, 55%, 0.5);
    --lumo-primary-color-10pct: hsla(214, 90%, 63%, 0.1);
    --lumo-primary-text-color: hsl(214, 100%, 70%);
    --lumo-primary-contrast-color: #FFF;

    /* Error */
    --lumo-error-color: hsl(3, 90%, 63%);
    --lumo-error-color-50pct: hsla(3, 90%, 63%, 0.5);
    --lumo-error-color-10pct: hsla(3, 90%, 63%, 0.1);
    --lumo-error-text-color: hsl(3, 100%, 67%);

    /* Success */
    --lumo-success-color: hsl(145, 65%, 42%);
    --lumo-success-color-50pct: hsla(145, 65%, 42%, 0.5);
    --lumo-success-color-10pct: hsla(145, 65%, 42%, 0.1);
    --lumo-success-text-color: hsl(145, 85%, 47%);
  }

  html {
    color: var(--lumo-body-text-color);
    background-color: var(--lumo-base-color);
  }

  [theme~="dark"] {
    color: var(--lumo-body-text-color);
    background-color: var(--lumo-base-color);
  }

  h1,
  h2,
  h3,
  h4,
  h5,
  h6 {
    color: var(--lumo-header-text-color);
  }

  a {
    color: var(--lumo-primary-text-color);
  }

  blockquote {
    color: var(--lumo-secondary-text-color);
  }

  code,
  pre {
    background-color: var(--lumo-contrast-10pct);
    border-radius: var(--lumo-border-radius-m);
  }
`;
registerStyles('', color, {moduleId: 'lumo-color'});

export { color };
const colorLegacy = css`

  :host {
    color: var(--lumo-body-text-color) !important;
    background-color: var(--lumo-base-color) !important;
  }
`;
registerStyles('', colorLegacy, {moduleId: 'lumo-color-legacy', include: ['lumo-color']});

export { colorLegacy };
```
</details>

<details>
<summary>sizing.js</summary>

```js
import './version.js';
import { css } from '@vaadin/vaadin-themable-mixin/register-styles.js';
const sizing = css`
:host {
  --lumo-size-xs: 1.625rem;
  --lumo-size-s: 1.875rem;
  --lumo-size-m: 2.25rem;
  --lumo-size-l: 2.75rem;
  --lumo-size-xl: 3.5rem;

  /* Icons */
  --lumo-icon-size-s: 1.25em;
  --lumo-icon-size-m: 1.5em;
  --lumo-icon-size-l: 2.25em;
  /* For backwards compatibility */
  --lumo-icon-size: var(--lumo-icon-size-m);
}
`;
const $tpl = document.createElement('template');
$tpl.innerHTML = `<custom-style><style>${sizing.toString().replace(':host', 'html')}</style></custom-style>`;
document.head.appendChild($tpl.content);

export { sizing };
```
</details>

<details>
<summary>spacing.js</summary>

```js
import './version.js';
import { css } from '@vaadin/vaadin-themable-mixin/register-styles.js';
const spacing = css`
:host {
  /* Square */
  --lumo-space-xs: 0.25rem;
  --lumo-space-s: 0.5rem;
  --lumo-space-m: 1rem;
  --lumo-space-l: 1.5rem;
  --lumo-space-xl: 2.5rem;

  /* Wide */
  --lumo-space-wide-xs: calc(var(--lumo-space-xs) / 2) var(--lumo-space-xs);
  --lumo-space-wide-s: calc(var(--lumo-space-s) / 2) var(--lumo-space-s);
  --lumo-space-wide-m: calc(var(--lumo-space-m) / 2) var(--lumo-space-m);
  --lumo-space-wide-l: calc(var(--lumo-space-l) / 2) var(--lumo-space-l);
  --lumo-space-wide-xl: calc(var(--lumo-space-xl) / 2) var(--lumo-space-xl);

  /* Tall */
  --lumo-space-tall-xs: var(--lumo-space-xs) calc(var(--lumo-space-xs) / 2);
  --lumo-space-tall-s: var(--lumo-space-s) calc(var(--lumo-space-s) / 2);
  --lumo-space-tall-m: var(--lumo-space-m) calc(var(--lumo-space-m) / 2);
  --lumo-space-tall-l: var(--lumo-space-l) calc(var(--lumo-space-l) / 2);
  --lumo-space-tall-xl: var(--lumo-space-xl) calc(var(--lumo-space-xl) / 2);
}
`;
const $tpl = document.createElement('template');
$tpl.innerHTML = `<custom-style><style>${spacing.toString().replace(':host', 'html')}</style></custom-style>`;
document.head.appendChild($tpl.content);

export { spacing };
```
</details>

<details>
<summary>style.js</summary>

```js
import './version.js';
import { css } from '@vaadin/vaadin-themable-mixin/register-styles.js';
const style = css`
:host {
  /* Border radius */
  --lumo-border-radius-s: 0.25em; /* Checkbox, badge, date-picker year indicator, etc */
  --lumo-border-radius-m: var(--lumo-border-radius, 0.25em); /* Button, text field, menu overlay, etc */
  --lumo-border-radius-l: 0.5em; /* Dialog, notification, etc */
  --lumo-border-radius: 0.25em; /* Deprecated */

  /* Shadow */
  --lumo-box-shadow-xs: 0 1px 4px -1px var(--lumo-shade-50pct);
  --lumo-box-shadow-s: 0 2px 4px -1px var(--lumo-shade-20pct), 0 3px 12px -1px var(--lumo-shade-30pct);
  --lumo-box-shadow-m: 0 2px 6px -1px var(--lumo-shade-20pct), 0 8px 24px -4px var(--lumo-shade-40pct);
  --lumo-box-shadow-l: 0 3px 18px -2px var(--lumo-shade-20pct), 0 12px 48px -6px var(--lumo-shade-40pct);
  --lumo-box-shadow-xl: 0 4px 24px -3px var(--lumo-shade-20pct), 0 18px 64px -8px var(--lumo-shade-40pct);

  /* Clickable element cursor */
  --lumo-clickable-cursor: default;
}
`;
const $tpl = document.createElement('template');
$tpl.innerHTML = `<custom-style><style>${style.toString().replace(':host', 'html')}</style></custom-style>`;
document.head.appendChild($tpl.content);

export { style };
```
</details>

<details>
<summary>typography.js</summary>

```js
import './version.js';
import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/register-styles.js';
const font = css`
:host {
  /* Font families */
  --lumo-font-family: -apple-system, BlinkMacSystemFont, "Roboto", "Segoe UI", Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";

  /* Font sizes */
  --lumo-font-size-xxs: .75rem;
  --lumo-font-size-xs: .8125rem;
  --lumo-font-size-s: .875rem;
  --lumo-font-size-m: 1rem;
  --lumo-font-size-l: 1.125rem;
  --lumo-font-size-xl: 1.375rem;
  --lumo-font-size-xxl: 1.75rem;
  --lumo-font-size-xxxl: 2.5rem;

  /* Line heights */
  --lumo-line-height-xs: 1.25;
  --lumo-line-height-s: 1.375;
  --lumo-line-height-m: 1.625;
}
`;
const $tpl = document.createElement('template');
$tpl.innerHTML = `<custom-style><style>${font.toString().replace(':host', 'html')}</style></custom-style>`;
document.head.appendChild($tpl.content);

export { font };
const typography = css`

  html {
    font-family: var(--lumo-font-family);
    font-size: var(--lumo-font-size, var(--lumo-font-size-m));
    line-height: var(--lumo-line-height-m);
    -webkit-text-size-adjust: 100%;
    -webkit-font-smoothing: antialiased;
    -moz-osx-font-smoothing: grayscale;
  }

  /* Can’t combine with the above selector because that doesn’t work in browsers without native shadow dom */
  :host {
    font-family: var(--lumo-font-family);
    font-size: var(--lumo-font-size, var(--lumo-font-size-m));
    line-height: var(--lumo-line-height-m);
    -webkit-text-size-adjust: 100%;
    -webkit-font-smoothing: antialiased;
    -moz-osx-font-smoothing: grayscale;
  }

  small,
  [theme~="font-size-s"] {
    font-size: var(--lumo-font-size-s);
    line-height: var(--lumo-line-height-s);
  }

  [theme~="font-size-xs"] {
    font-size: var(--lumo-font-size-xs);
    line-height: var(--lumo-line-height-xs);
  }

  h1,
  h2,
  h3,
  h4,
  h5,
  h6 {
    font-weight: 600;
    line-height: var(--lumo-line-height-xs);
    margin-top: 1.25em;
  }

  h1 {
    font-size: var(--lumo-font-size-xxxl);
    margin-bottom: 0.75em;
  }

  h2 {
    font-size: var(--lumo-font-size-xxl);
    margin-bottom: 0.5em;
  }

  h3 {
    font-size: var(--lumo-font-size-xl);
    margin-bottom: 0.5em;
  }

  h4 {
    font-size: var(--lumo-font-size-l);
    margin-bottom: 0.5em;
  }

  h5 {
    font-size: var(--lumo-font-size-m);
    margin-bottom: 0.25em;
  }

  h6 {
    font-size: var(--lumo-font-size-xs);
    margin-bottom: 0;
    text-transform: uppercase;
    letter-spacing: 0.03em;
  }

  p,
  blockquote {
    margin-top: 0.5em;
    margin-bottom: 0.75em;
  }

  a {
    text-decoration: none;
  }

  a:hover {
    text-decoration: underline;
  }

  hr {
    display: block;
    align-self: stretch;
    height: 1px;
    border: 0;
    padding: 0;
    margin: var(--lumo-space-s) calc(var(--lumo-border-radius-m) / 2);
    background-color: var(--lumo-contrast-10pct);
  }

  blockquote {
    border-left: 2px solid var(--lumo-contrast-30pct);
  }

  b,
  strong {
    font-weight: 600;
  }

  /* RTL specific styles */

  blockquote[dir="rtl"] {
    border-left: none;
    border-right: 2px solid var(--lumo-contrast-30pct);
  }
`;
registerStyles('', typography, {moduleId: 'lumo-typography'});

export { typography };
```
</details>

<details>
<summary>mixins/field-button.js</summary>

```js
import '../color.js';
import '../font-icons.js';
import '../sizing.js';
import '../style.js';
import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/register-styles.js';
const fieldButton = css`
  [part$="button"] {
    flex: none;
    width: 1em;
    height: 1em;
    line-height: 1;
    font-size: var(--lumo-icon-size-m);
    text-align: center;
    color: var(--lumo-contrast-60pct);
    transition: 0.2s color;
    cursor: var(--lumo-clickable-cursor);
  }

  :host(:not([readonly])) [part$="button"]:hover {
    color: var(--lumo-contrast-90pct);
  }

  :host([disabled]) [part$="button"],
  :host([readonly]) [part$="button"] {
    color: var(--lumo-contrast-20pct);
  }

  [part$="button"]::before {
    font-family: "lumo-icons";
    display: block;
  }
`;
registerStyles('', fieldButton, {moduleId: 'lumo-field-button'});

export { fieldButton };
```
</details>

<details>
<summary>mixins/menu-overlay.js</summary>

```js
/* Split as a separate module because combo box can only use the "fullscreen" styles */
/*
  FIXME(polymer-modulizer): the above comments were extracted
  from HTML and may be out of place here. Review them and
  then delete this comment!
*/
import '../spacing.js';

import '../style.js';
import './overlay.js';
import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/register-styles.js';
const menuOverlayCore = css`
  :host([opening]),
  :host([closing]) {
    animation: 0.14s lumo-overlay-dummy-animation;
  }

  [part="overlay"] {
    will-change: opacity, transform;
  }

  :host([opening]) [part="overlay"] {
    animation: 0.1s lumo-menu-overlay-enter ease-out both;
  }

  @keyframes lumo-menu-overlay-enter {
    0% {
      opacity: 0;
      transform: translateY(-4px);
    }
  }

  :host([closing]) [part="overlay"] {
    animation: 0.1s lumo-menu-overlay-exit both;
  }

  @keyframes lumo-menu-overlay-exit {
    100% {
      opacity: 0;
    }
  }
`;
registerStyles('', menuOverlayCore, {moduleId: 'lumo-menu-overlay-core'});

export { menuOverlayCore };

const menuOverlay = css`
      /* Small viewport (bottom sheet) styles */
      /* Use direct media queries instead of the state attributes ([phone] and [fullscreen]) provided by the elements */
      @media (max-width: 420px), (max-height: 420px) {
        :host {
          top: 0 !important;
          right: 0 !important;
          bottom: var(--vaadin-overlay-viewport-bottom, 0) !important;
          left: 0 !important;
          align-items: stretch !important;
          justify-content: flex-end !important;
        }

        [part="overlay"] {
          max-height: 50vh;
          width: 100vw;
          border-radius: 0;
          box-shadow: var(--lumo-box-shadow-xl);
        }

        /* The content part scrolls instead of the overlay part, because of the gradient fade-out */
        [part="content"] {
          padding: 30px var(--lumo-space-m);
          max-height: inherit;
          box-sizing: border-box;
          -webkit-overflow-scrolling: touch;
          overflow: auto;
          -webkit-mask-image: linear-gradient(transparent, #000 40px, #000 calc(100% - 40px), transparent);
          mask-image: linear-gradient(transparent, #000 40px, #000 calc(100% - 40px), transparent);
        }

        [part="backdrop"] {
          display: block;
        }

        /* Animations */

        :host([opening]) [part="overlay"] {
          animation: 0.2s lumo-mobile-menu-overlay-enter cubic-bezier(.215, .61, .355, 1) both;
        }

        :host([closing]),
        :host([closing]) [part="backdrop"] {
          animation-delay: 0.14s;
        }

        :host([closing]) [part="overlay"] {
          animation: 0.14s 0.14s lumo-mobile-menu-overlay-exit cubic-bezier(.55, .055, .675, .19) both;
        }
      }

      @keyframes lumo-mobile-menu-overlay-enter {
        0% {
          transform: translateY(150%);
        }
      }

      @keyframes lumo-mobile-menu-overlay-exit {
        100% {
          transform: translateY(150%);
        }
      }
`;
registerStyles('', menuOverlay, {moduleId: 'lumo-menu-overlay', include: ['lumo-overlay', 'lumo-menu-overlay-core']});

export { menuOverlay };
```
</details>

<details>
<summary>mixins/overlay.js</summary>

```js
import '../color.js';
import '../spacing.js';
import '../style.js';
import '../typography.js';
import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/register-styles.js';
const overlay = css`
  :host {
    top: var(--lumo-space-m);
    right: var(--lumo-space-m);
    bottom: var(--lumo-space-m);
    left: var(--lumo-space-m);
    /* Workaround for Edge issue (only on Surface), where an overflowing vaadin-list-box inside vaadin-select-overlay makes the overlay transparent */
    /* stylelint-disable-next-line */
    outline: 0px solid transparent;
  }

  [part="overlay"] {
    background-color: var(--lumo-base-color);
    background-image: linear-gradient(var(--lumo-tint-5pct), var(--lumo-tint-5pct));
    border-radius: var(--lumo-border-radius-m);
    box-shadow: 0 0 0 1px var(--lumo-shade-5pct), var(--lumo-box-shadow-m);
    color: var(--lumo-body-text-color);
    font-family: var(--lumo-font-family);
    font-size: var(--lumo-font-size-m);
    font-weight: 400;
    line-height: var(--lumo-line-height-m);
    letter-spacing: 0;
    text-transform: none;
    -webkit-text-size-adjust: 100%;
    -webkit-font-smoothing: antialiased;
    -moz-osx-font-smoothing: grayscale;
  }

  [part="content"] {
    padding: var(--lumo-space-xs);
  }

  [part="backdrop"] {
    background-color: var(--lumo-shade-20pct);
    animation: 0.2s lumo-overlay-backdrop-enter both;
    will-change: opacity;
  }

  @keyframes lumo-overlay-backdrop-enter {
    0% {
      opacity: 0;
    }
  }

  :host([closing]) [part="backdrop"] {
    animation: 0.2s lumo-overlay-backdrop-exit both;
  }

  @keyframes lumo-overlay-backdrop-exit {
    100% {
      opacity: 0;
    }
  }

  @keyframes lumo-overlay-dummy-animation {
    0% { opacity: 1; }
    100% { opacity: 1; }
  }
`;
registerStyles('', overlay, {moduleId: 'lumo-overlay'});

export { overlay };
```
</details>

<details>
<summary>mixins/required-field.js</summary>

```js
import '../color.js';
import '../spacing.js';
import '../style.js';
import '../typography.js';
import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/register-styles.js';
const requiredField = css`
  [part="label"] {
    align-self: flex-start;
    color: var(--lumo-secondary-text-color);
    font-weight: 500;
    font-size: var(--lumo-font-size-s);
    margin-left: calc(var(--lumo-border-radius-m) / 4);
    transition: color 0.2s;
    line-height: 1;
    padding-bottom: 0.5em;
    overflow: hidden;
    white-space: nowrap;
    text-overflow: ellipsis;
    position: relative;
    max-width: 100%;
    box-sizing: border-box;
  }

  :host([has-label])::before {
    margin-top: calc(var(--lumo-font-size-s) * 1.5);
  }

  :host([has-label]) {
    padding-top: var(--lumo-space-m);
  }

  :host([required]) [part="label"] {
    padding-right: 1em;
  }

  [part="label"]::after {
    content: var(--lumo-required-field-indicator, "•");
    transition: opacity 0.2s;
    opacity: 0;
    color: var(--lumo-primary-text-color);
    position: absolute;
    right: 0;
    width: 1em;
    text-align: center;
  }

  :host([required]:not([has-value])) [part="label"]::after {
    opacity: 1;
  }

  :host([invalid]) [part="label"]::after {
    color: var(--lumo-error-text-color);
  }

  [part="error-message"] {
    margin-left: calc(var(--lumo-border-radius-m) / 4);
    font-size: var(--lumo-font-size-xs);
    line-height: var(--lumo-line-height-xs);
    color: var(--lumo-error-text-color);
    will-change: max-height;
    transition: 0.4s max-height;
    max-height: 5em;
  }

  /* Margin that doesn’t reserve space when there’s no error message */
  [part="error-message"]:not(:empty)::before,
  [part="error-message"]:not(:empty)::after {
    content: "";
    display: block;
    height: 0.4em;
  }

  :host(:not([invalid])) [part="error-message"] {
    max-height: 0;
    overflow: hidden;
  }

  /* RTL specific styles */

  :host([dir="rtl"]) [part="label"] {
    margin-left: 0;
    margin-right: calc(var(--lumo-border-radius-m) / 4);
  }

  :host([required][dir="rtl"]) [part="label"] {
    padding-left: 1em;
    padding-right: 0;
  }

  :host([dir="rtl"]) [part="label"]::after {
    right: auto;
    left: 0;
  }

  :host([dir="rtl"]) [part="error-message"] {
    margin-left: 0;
    margin-right: calc(var(--lumo-border-radius-m) / 4);
  }
`;
registerStyles('', requiredField, {moduleId: 'lumo-required-field'});

export { requiredField };
```
</details>