### PR TITLE
chore: fix modulizer to use correct Lumo

### DIFF
--- a/.bowerrc
+++ b/.bowerrc
@@ -1,0 +1,5 @@
+{
+  "scripts": {
+    "postinstall": "rm -rf bower_components/vaadin-lumo-styles"
+  }
+}


### PR DESCRIPTION
This is a fix for the issue which we faced many times when converting `vaadin-lumo-styles` package to Polymer 3.

The reason is that some components used as `devDependencies` for kitchen sink demo pull another copy of Lumo.
In some cases `polymer-modulzier` picks files from `bower_components/vaadin-lumo-styles` instead of local files.

Here I'm using Bower postinstall script to remove that duplicate folder (the demo works without it).